### PR TITLE
Catching exception if no db data available

### DIFF
--- a/e3dc_to_mqtt/e3dc_to_mqtt_base.py
+++ b/e3dc_to_mqtt/e3dc_to_mqtt_base.py
@@ -349,6 +349,8 @@ class E3DCClient:
                 data["date"] = request_date.strftime("%Y/%m/%d")
                 return data
             return None
+        except Exception:
+            LOGGER.error("failed to get_db_data_day")
         finally:
             self.__lock.release()
 
@@ -363,5 +365,7 @@ class E3DCClient:
                 data["date"] = request_date.strftime("%Y/%m")
                 return data
             return None
+        except Exception:
+            LOGGER.error("failed to get_db_data_month")
         finally:
             self.__lock.release()

--- a/e3dc_to_mqtt/e3dc_to_mqtt_base.py
+++ b/e3dc_to_mqtt/e3dc_to_mqtt_base.py
@@ -264,7 +264,7 @@ class E3DCClient:
                     LOGGER.debug(f"Powermeter index {index} found")
                     return index
             except Exception:
-                LOGGER.error(f"Powermeter index {index} failed")
+                LOGGER.debug(f"Powermeter index {index} failed")
         return None
 
     async def get_powermeter_data(self):
@@ -366,6 +366,6 @@ class E3DCClient:
                 return data
             return None
         except Exception:
-            LOGGER.error("failed to get_db_data_month")
+            LOGGER.error("failed to get_db_data_month, probably no data available yet")
         finally:
             self.__lock.release()


### PR DESCRIPTION
When starting on a new system, there won't be db_data of the previous month available, which results in a SendError. This error is now catched and the app continues.